### PR TITLE
fix: swallow EBADF on resize() when PTY fd is already closed

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -274,7 +274,13 @@ export class UnixTerminal extends Terminal {
     if (cols <= 0 || rows <= 0 || isNaN(cols) || isNaN(rows) || cols === Infinity || rows === Infinity) {
       throw new Error('resizing must be done using positive cols and rows');
     }
-    pty.resize(this._fd, cols, rows);
+    try {
+      pty.resize(this._fd, cols, rows);
+    } catch (e: any) {
+      // EBADF means the fd is already closed (PTY destroyed before resize fires); ignore it
+      if (e?.code === 'EBADF' || e?.message?.includes('EBADF')) { return; }
+      throw e;
+    }
     this._cols = cols;
     this._rows = rows;
   }


### PR DESCRIPTION
  pty.resize() throws with message 'ioctl(2) failed, EBADF' when the PTY
  file descriptor has already been closed (e.g. the process exited and the
  fd was destroyed before a resize event fired).

  Observed crashing @google/gemini-cli on Linux when a shell command
  completes and a terminal resize triggers before the PTY is fully torn down.

  Catch EBADF by both error code and message (the native addon sets the
  message but not error.code) and silently return instead of crashing.