### PR TITLE
fix: close slave fd in parent after posix_spawn

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -290,6 +290,7 @@ NAN_METHOD(PtyFork) {
     auto error = posix_spawn(&pid, helper_path, &acts, &attrs, argv, env);
 
     close(comms_pipe[1]);
+    close(slave);
 
     // reenable signals
     pthread_sigmask(SIG_SETMASK, &oldmask, NULL);


### PR DESCRIPTION
## Summary

Fixes #13. Adds `close(slave)` after `posix_spawn` in `PtyFork` to prevent leaking the slave file descriptor in the parent process.

## Problem

`openpty()` returns both master and slave fds. The slave is passed to the child via `posix_spawn_file_actions_adddup2`, but the parent never closes its copy. This leaks one fd per PTY spawn, eventually exhausting the system PTY pool (512 on macOS).

## Fix

One line: `close(slave)` right after `close(comms_pipe[1])`, where the parent is already cleaning up fds it no longer needs.

## Verification

Before fix — after spawn + exit + destroy, `lsof` shows a leaked `/dev/ptmx` fd (the slave):
```
node  PID user  11u  CHR  15,16  0t0  605  /dev/ptmx   ← leaked slave
```

After fix — zero leaked ptmx fds after spawn + exit + destroy.