### PR TITLE
Fix types discovery in TypeScript 6

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,7 +32,12 @@ function buildTopPackage() {
     version: VERSION,
     license: "MIT",
     type: "commonjs",
-    exports: "./index.js",
+    exports: {
+      ".": {
+        types: "./node-pty.d.ts",
+        default: "./index.js",
+      },
+    },
     types: "./node-pty.d.ts",
     repository: {
       type: "git",


### PR DESCRIPTION
Hey Simon! It's been a while :)

TypeScript 6 (and maybe some earlier versions, too?) ignores the package.json's "types" field when the "exports" field is present, which was causing it to treat this package as untyped. So this PR adds the types to the exports field.